### PR TITLE
feat: disallow brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,127 @@
 # textlint-rule-no-bracket
 
-> [!WARNING]
-> This repo is WIP
+textlint rule for no bracket
+
+## 📖 Rule Details
+
+This rule checks whether the disallowed brackets are present in the sentences.
+
+## 🍭 Example
+
+For example, if full-width parenthesis and lenticular brackets are not allowed, the following are NG and OK:
+
+### ❌ NG
+
+```
+They are coming to our house after work（around six o’ clock）.
+
+【重要】これは(秘密)です。
+```
+
+### ✅ OK
+
+```
+They are coming to our house after work (around six o’ clock).
+
+[重要] これは(秘密)です。
+```
+
+## 💿 Installlation
+
+Install with [npm](https://www.npmjs.com/):
+
+```sh
+npm install textlint-rule-no-bracket
+```
+
+## 🚀 Usages
+
+### Configure `.textlintrc`
+
+It’s recommended that this rule is used in `.textlintrc`.
+
+**This rule allows all brackets by default**. So you need to put to `disallowBrackets` option which brackets you do not allow.
+
+Below is an example of using full-width parenthesis and lenticular brackets:
+
+```js
+const { FullWidthParenthesis, LenticularBrackets } =
+  require('textlint-rule-no-bracket').brackes
+
+module.exports = {
+  rules: {
+    'no-bracket': {
+      disallowBrackets: [FullWidthParenthesis, LenticularBrackets]
+    }
+  }
+}
+```
+
+### Custom disallow brackets
+
+If you would like to use other brackets, you can put the bracket scheme.
+
+You must define the bracket scheme, which is an object with following the properties:
+
+- `name`: the name of the bracket
+- `start`: the openning bracket character
+- `end`: the closing bracket character
+
+```js
+module.exports = {
+  rules: {
+    'no-bracket': {
+      disallowBrackets: [
+        {
+          name: 'Double Angle Quotation Mark',
+          start: '«',
+          end: '»'
+        }
+      ]
+    }
+  }
+}
+```
+
+## 🔨 Support Built-in Brackets
+
+- Parenthesis: `(` and `)`
+- Square Brackets: `[` and `]`
+- Curly Brackets: `{` and `}`
+- Full-Width Parenthesis: `（` and `）`
+- Full-Width Square Brackets: `［` and `］`
+- Full-Width Curly Brackets: `｛` and `｝`
+- Corner Brackets: `「` and `」`
+- White Corner Brackets: `『` and `』`
+- Less-Than and Greater-Than Angle Brackets: `<` and `>`
+- Lenticular Brackets: `【` and `】`
+- White Lenticular Brackets: `〖` and `〗`
+- White Square Brackets: `〚` and `〛`
+
+If you would like to use these built-in brackets and custom brackets, you can use spread syntax (`...`) as follows:
+
+```js
+const { defaultBrackets } = require('textlint-rule-no-bracket')
+
+module.exports = {
+  rules: {
+    'no-bracket': {
+      disallowBrackets: [
+        {
+          name: 'Double Angle Quotation Mark',
+          start: '«',
+          end: '»'
+        },
+        ...defaultBrackets
+      ]
+    }
+  }
+}
+```
+
+## 🙌 Contributing guidelines
+
+If you are interested in contributing to `textlint-rule-no-bracket`, I highly recommend checking out [the contributing guidelines](/CONTRIBUTING.md) here. You'll find all the relevant information such as [how to make a PR](/CONTRIBUTING.md#pull-request-guidelines), [how to setup development](/CONTRIBUTING.md#development-setup)) etc., there.
 
 ## ©️ License
 

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 
 ## ©️ License
 
-[MIT](http://opensource.org/licenses/MIT)
+MIT ©️ 2024 [kazupon](https://github.com/kazupon)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you would like to use other brackets, you can put the bracket scheme.
 You must define the bracket scheme, which is an object with following the properties:
 
 - `name`: the name of the bracket
-- `start`: the openning bracket character
+- `start`: the opening bracket character
 - `end`: the closing bracket character
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "textlint-rule-no-bracket",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1"
+      },
       "devDependencies": {
         "@eslint/js": "^8.56.0",
         "@textlint/types": "^14.0.4",
@@ -2352,8 +2356,7 @@
     "node_modules/@types/unist": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
-      "dev": true
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.10.0",
@@ -2870,8 +2873,7 @@
     "node_modules/boundary": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
-      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
-      "dev": true
+      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -7427,6 +7429,22 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/sentence-splitter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-5.0.0.tgz",
+      "integrity": "sha512-9Mvf7L8vwpPzkH0/HtXzCbmVkyj4aQXdeG7h8ighRvO0hvcZEy2OUEjeIlnM/z4EX4vBacEfpESC65Oa2rWOig==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "structured-source": "^4.0.0"
+      }
+    },
+    "node_modules/sentence-splitter/node_modules/@textlint/ast-node-types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
+      "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
+      "license": "MIT"
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -7789,7 +7807,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
       "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
-      "dev": true,
       "dependencies": {
         "boundary": "^2.0.0"
       }
@@ -7848,6 +7865,23 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/textlint-rule-helper": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.3.1.tgz",
+      "integrity": "sha512-b1bijvyiUmKinfFE5hkQMSXs3Ky8jyZ3Y6SOoTRJKV9HLL2LWUVFAUezO7z4FpAkVvYruDYWCwA5qWV8GmvyUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "structured-source": "^4.0.0",
+        "unist-util-visit": "^2.0.3"
+      }
+    },
+    "node_modules/textlint-rule-helper/node_modules/@textlint/ast-node-types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
+      "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
+      "license": "MIT"
     },
     "node_modules/textlint-scripts": {
       "version": "14.0.4",
@@ -8297,7 +8331,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
       "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -8316,11 +8349,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-visit-parents": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
       "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "packageManager": "npm@10.8.0",
   "scripts": {
     "prepare": "git config --local core.hooksPath .githooks",
-    "prepublish": "npm run build",
     "changelog": "gh-changelogen --repo=kazupon/textlint-rule-no-bracket",
     "release": "bumpp --commit \"release: v%s\" --push --tag",
     "clean": "git clean -fx",
@@ -44,6 +43,10 @@
     "fix": "run-p fix:*",
     "fix:prettier": "prettier . --cache --write",
     "fix:eslint": "npm run lint:eslint -- --fix"
+  },
+  "dependencies": {
+    "sentence-splitter": "^5.0.0",
+    "textlint-rule-helper": "^2.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",

--- a/src/BracketMaker.ts
+++ b/src/BracketMaker.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Author: kazuya kawaguchi (a.k.a. kazupon)
+// Forked: https://github.com/textlint-rule/textlint-rule-no-unmatched-pair/blob/95ef2dfe8e61487d37433deeb5de7731add9e11d/src/parser/PairMaker.js
+
+import type { SourceCode } from './SourceCode'
+import type { Brackets } from './brackets'
+
+export function createBracketMarker(bracketsList: Brackets[]) {
+  const bracketMarksEntries = bracketsList
+    .map<[[string, Brackets], [string, Brackets]]>(mark => {
+      return [
+        [mark.start, mark],
+        [mark.end, mark]
+      ]
+    })
+    .flat(1)
+
+  const bracketMarksKeyMap = new Map(bracketMarksEntries)
+  const matchPair = (str: string) => {
+    return bracketMarksKeyMap.get(str)
+  }
+
+  return {
+    mark(sourceCode: SourceCode) {
+      const str = sourceCode.read()
+      if (!str) {
+        return
+      }
+
+      const matchedPair = matchPair(str)
+      if (!matchedPair) {
+        return
+      }
+
+      // support nested pair
+      if (sourceCode.isInContext(matchedPair)) {
+        // check that string is end mark?
+        const pair = bracketsList.find(pair => pair.end === str)
+        if (pair) {
+          sourceCode.leaveContext(pair)
+        }
+      } else {
+        const pair = bracketsList.find(pair => pair.start === str)
+        if (pair) {
+          sourceCode.enterContext(pair)
+        }
+      }
+    }
+  }
+}

--- a/src/SourceCode.ts
+++ b/src/SourceCode.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Author: kazuya kawaguchi (a.k.a. kazupon)
+// Forked: https://github.com/textlint-rule/textlint-rule-no-unmatched-pair/blob/95ef2dfe8e61487d37433deeb5de7731add9e11d/src/parser/SourceCode.js
+
+import type { Brackets } from './brackets'
+
+export type SourceCode = ReturnType<typeof createSourceCode>
+
+export function createSourceCode(text: string) {
+  const _text: string = text
+  const _contextLocations: { index: number; brackets: Brackets }[] = []
+  const _matchedLocations: { index: number; brackets: Brackets }[] = []
+  let _index: number = 0
+
+  const read = () => _text[_index]
+  const canRead = () => read() !== undefined
+  const peek = (index = 1) => (_index += index)
+
+  return {
+    read,
+    canRead,
+    peek,
+    get index() {
+      return _index
+    },
+    get contextLocations() {
+      return _contextLocations
+    },
+    get matchedLocations() {
+      return _matchedLocations
+    },
+    enterContext(brackets: Brackets) {
+      _contextLocations.push({
+        index: _index + 1,
+        brackets
+      })
+    },
+    leaveContext(brackets: Brackets) {
+      const index = _contextLocations.findIndex(context => {
+        return context.brackets.name === brackets.name
+      })
+      if (index !== -1) {
+        const ctxLoc = _contextLocations[index]
+        _matchedLocations.push(ctxLoc)
+        _contextLocations.splice(index, 1)
+      }
+    },
+    isInContext(brackets: Brackets) {
+      return _contextLocations.some(
+        contextLocation => contextLocation.brackets.name === brackets.name
+      )
+    }
+  }
+}

--- a/src/brackets.ts
+++ b/src/brackets.ts
@@ -11,11 +11,11 @@ export interface Brackets {
    */
   name: string
   /**
-   * The opening bracket.
+   * The opening bracket character.
    */
   start: string
   /**
-   * The closing bracket.
+   * The closing bracket character.
    */
   end: string
 }

--- a/src/brackets.ts
+++ b/src/brackets.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Author: kazuya kawaguchi(a.k.a.kazupon)
+
 /**
  * Brackets Type
  * @description An interface that defines the bracket type.

--- a/src/brackets.ts
+++ b/src/brackets.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Author: kazuya kawaguchi(a.k.a.kazupon)
+// Author: kazuya kawaguchi (a.k.a. kazupon)
 
 /**
  * Brackets Type

--- a/src/brackets.ts
+++ b/src/brackets.ts
@@ -1,0 +1,142 @@
+/**
+ * Brackets Type
+ * @description An interface that defines the bracket type.
+ */
+export interface Brackets {
+  /**
+   * The name of the bracket.
+   */
+  name: string
+  /**
+   * The opening bracket.
+   */
+  start: string
+  /**
+   * The closing bracket.
+   */
+  end: string
+}
+
+/**
+ * Built-in Brackets
+ */
+
+/**
+ * Parenthesis
+ * @see https://en.wikipedia.org/wiki/Bracket#Parentheses_or_round_brackets
+ */
+export const Parenthesis: Brackets = {
+  name: 'Parenthesis',
+  start: '(', // unicode: U+0028
+  end: ')' // unicode: U+0029
+}
+
+/**
+ * Square Brackets
+ * @see https://en.wikipedia.org/wiki/Bracket#Square_brackets
+ */
+export const SquareBrackets: Brackets = {
+  name: 'Square Brackets',
+  start: '[', // unicode: U+005B
+  end: ']' // unicode: U+005D
+}
+
+/**
+ * Curly Brackets
+ * @see https://en.wikipedia.org/wiki/Bracket#Curly_brackets
+ */
+export const CurlyBrackets: Brackets = {
+  name: 'Curly Brackets',
+  start: '{', // unicode: U+007B
+  end: '}' // unicode: U+007D
+}
+
+/**
+ * Full-Width Parenthesis
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E4%B8%B8%E6%8B%AC%E5%BC%A7%EF%BC%88_%EF%BC%89
+ */
+export const FullWidthParenthesis: Brackets = {
+  name: 'Full-Width Parenthesis',
+  start: '（', // unicode: U+FF08
+  end: '）' // unicode: U+FF09
+}
+
+/**
+ * Full-Width Square Brackets
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E8%A7%92%E6%8B%AC%E5%BC%A7%EF%BC%BB_%EF%BC%BD
+ */
+export const FullWidthSquareBrackets: Brackets = {
+  name: 'Full-Width Square Brackets',
+  start: '［', // unicode: U+FF3B
+  end: '］' // unicode: U+FF3D
+}
+
+/**
+ * Full-Width Curly Brackets
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E6%B3%A2%E6%8B%AC%E5%BC%A7%EF%BD%9B_%EF%BD%9D
+ */
+export const FullWidthCurlyBrackets: Brackets = {
+  name: 'Full-Width Curly Brackets',
+  start: '｛', // unicode: U+FF5B
+  end: '｝' // unicode: U+FF5D
+}
+
+/**
+ * Corner Brackets
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E9%89%A4%E6%8B%AC%E5%BC%A7%E3%80%8C_%E3%80%8D
+ */
+export const CornerBrackets: Brackets = {
+  name: 'Corner Brackets',
+  start: '「', // unicode: U+300C
+  end: '」' // unicode: U+300D
+}
+
+/**
+ * White Corner Brackets
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E4%BA%8C%E9%87%8D%E9%89%A4%E6%8B%AC%E5%BC%A7%E3%80%8E_%E3%80%8F
+ */
+export const WhiteCornerBrackets: Brackets = {
+  name: 'White Corner Brackets',
+  start: '『', // unicode: U+300E
+  end: '』' // unicode: U+300F
+}
+
+/**
+ * Less-Than and Greater-Than Signs
+ * @see https://en.wikipedia.org/wiki/Bracket#Angle_brackets
+ */
+export const LessGreeterThanAngleBrackets: Brackets = {
+  name: 'Less-Than and Greater-Than Angle Brackets',
+  start: '<', // unicode: U+003C
+  end: '>' // unicode: U+003E
+}
+
+/**
+ * Lenticular Brackets
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E9%9A%85%E4%BB%98%E3%81%8D%E6%8B%AC%E5%BC%A7%E3%80%90_%E3%80%91
+ */
+export const LenticularBrackets: Brackets = {
+  name: 'Lenticular Brackets',
+  start: '【', // unicode: U+3010
+  end: '】' // unicode: U+3011
+}
+
+/**
+ * White Lenticular Brackets
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E9%9A%85%E4%BB%98%E3%81%8D%E6%8B%AC%E5%BC%A7%EF%BC%88%E7%99%BD%EF%BC%89%E3%80%96_%E3%80%97
+ */
+export const WhiteLenticularBrackets: Brackets = {
+  name: 'White Lenticular Brackets',
+  start: '〖', // unicode: U+3016
+  end: '〗' // unicode: U+3017
+}
+
+/**
+ * White Square Brackets
+ * @see https://ja.wikipedia.org/wiki/%E6%8B%AC%E5%BC%A7#%E4%BA%8C%E9%87%8D%E8%A7%92%E6%8B%AC%E5%BC%A7%E3%80%9A_%E3%80%9B
+ */
+export const WhiteSquareBrackets: Brackets = {
+  name: 'White Square Brackets',
+  start: '〚', // unicode: U+301A
+  end: '〛' // unicode: U+301B
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Author: kazuya kawaguchi (a.k.a. kazupon)
 
+import { splitAST, SentenceSplitterSyntax } from 'sentence-splitter'
+import { IgnoreNodeManager } from 'textlint-rule-helper'
 import {
   Parenthesis,
   SquareBrackets,
@@ -15,33 +17,92 @@ import {
   WhiteLenticularBrackets,
   WhiteSquareBrackets
 } from './brackets'
-import type { Brackets } from './brackets'
+import { createSourceCode } from './SourceCode'
+import { createBracketMarker } from './BracketMaker'
+
 import type { TextlintRuleModule } from '@textlint/types'
+import type { Brackets } from './brackets'
 
 export interface Options {
   disallowBrackets?: Brackets[]
 }
 
-const report: TextlintRuleModule<Options> = (_context, _options = {}) => {
-  // const { Syntax, RuleError, report, fixer, getSource, locator } = context
-  return {}
+const report: TextlintRuleModule<Options> = (context, options = {}) => {
+  const { Syntax, RuleError, report } = context
+  const disallowBrackets = options.disallowBrackets || []
+  const ignoreNodeManager = new IgnoreNodeManager()
+  return {
+    [Syntax.Paragraph](node) {
+      // @ts-expect-error FIXME: `splitAST` first argument miss-match
+      const sentences = splitAST(node)
+      // @ts-expect-error FIXME: `ignoreChildrenByTypes` first argument miss-match
+      ignoreNodeManager.ignoreChildrenByTypes(node, [
+        Syntax.CodeBlock,
+        Syntax.Code,
+        Syntax.Link,
+        Syntax.Strong,
+        Syntax.Emphasis,
+        Syntax.BlockQuote,
+        Syntax.Comment
+      ])
+      sentences.children
+        .filter(node => node.type === SentenceSplitterSyntax.Sentence)
+        .forEach(sentence => {
+          const source = createSourceCode(sentence.raw)
+          const pairMaker = createBracketMarker(disallowBrackets)
+          const sentenceIndex = sentence.range[0]
+          while (source.canRead()) {
+            // If the character is in ignored range, skip it
+            const characterIndex = sentenceIndex + source.index
+            if (!ignoreNodeManager.isIgnoredIndex(characterIndex)) {
+              pairMaker.mark(source)
+            }
+            source.peek()
+          }
+          // Report Error for each existing context keys
+          source.matchedLocations.forEach(ctxLoc => {
+            report(
+              node,
+              new RuleError(
+                `Disallow ${ctxLoc.brackets.name} '${ctxLoc.brackets.start}' and '${ctxLoc.brackets.end}'.`,
+                {
+                  index: sentenceIndex - node.range[0] + ctxLoc.index
+                }
+              )
+            )
+          })
+        })
+    }
+  }
 }
+
+/**
+ * Supports export of individual built-in brackets
+ */
+const brackets = {
+  Parenthesis,
+  SquareBrackets,
+  CurlyBrackets,
+  FullWidthParenthesis,
+  FullWidthSquareBrackets,
+  FullWidthCurlyBrackets,
+  CornerBrackets,
+  WhiteCornerBrackets,
+  LessGreeterThanAngleBrackets,
+  LenticularBrackets,
+  WhiteLenticularBrackets,
+  WhiteSquareBrackets
+}
+
+/**
+ * Supports export of all built-in brackets with Array
+ * ```
+ */
+const defaultBrackets = Object.values(brackets)
 
 export default {
   linter: report,
   fixer: report,
-  brackets: {
-    Parenthesis,
-    SquareBrackets,
-    CurlyBrackets,
-    FullWidthParenthesis,
-    FullWidthSquareBrackets,
-    FullWidthCurlyBrackets,
-    CornerBrackets,
-    WhiteCornerBrackets,
-    LessGreeterThanAngleBrackets,
-    LenticularBrackets,
-    WhiteLenticularBrackets,
-    WhiteSquareBrackets
-  }
+  brackets,
+  defaultBrackets
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,23 @@
+import {
+  Parenthesis,
+  SquareBrackets,
+  CurlyBrackets,
+  FullWidthParenthesis,
+  FullWidthSquareBrackets,
+  FullWidthCurlyBrackets,
+  CornerBrackets,
+  WhiteCornerBrackets,
+  LessGreeterThanAngleBrackets,
+  LenticularBrackets,
+  WhiteLenticularBrackets,
+  WhiteSquareBrackets
+} from './brackets'
+import type { Brackets } from './brackets'
 import type { TextlintRuleModule } from '@textlint/types'
 
-interface Options {}
+export interface Options {
+  disallowBrackets?: Brackets[]
+}
 
 const report: TextlintRuleModule<Options> = (_context, _options = {}) => {
   // const { Syntax, RuleError, report, fixer, getSource, locator } = context
@@ -9,5 +26,19 @@ const report: TextlintRuleModule<Options> = (_context, _options = {}) => {
 
 export default {
   linter: report,
-  fixer: report
+  fixer: report,
+  brackets: {
+    Parenthesis,
+    SquareBrackets,
+    CurlyBrackets,
+    FullWidthParenthesis,
+    FullWidthSquareBrackets,
+    FullWidthCurlyBrackets,
+    CornerBrackets,
+    WhiteCornerBrackets,
+    LessGreeterThanAngleBrackets,
+    LenticularBrackets,
+    WhiteLenticularBrackets,
+    WhiteSquareBrackets
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Author: kazuya kawaguchi (a.k.a. kazupon)
+
 import {
   Parenthesis,
   SquareBrackets,

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -1,9 +1,113 @@
 import TextLintTester from 'textlint-tester'
 import rule from '../src/index'
+import {
+  Parenthesis,
+  FullWidthParenthesis,
+  LenticularBrackets,
+  CornerBrackets
+} from '../src/brackets'
 
 const tester = new TextLintTester()
 
 tester.run('no-bracket', rule, {
-  valid: [],
-  invalid: []
+  valid: [
+    `{"{ABC}"}`,
+    'test {"{ABC`{"{ABC}"}`}"} ok.',
+    'これは(秘密)です。',
+    `John said "Hello World!".`,
+    '`(` is ok.',
+    '文字列リテラルには3種類ありますが、まずは`"`（ダブルクオート）と`\'`（シングルクオート）について見ていきます。',
+    `a is b.
+\`"\`（ダブルクオート）と\`'\`（シングルクオート）に意味的な違いはありません。
+この書籍では、\`"\`（ダブルクオート）を主に文字列リテラルとして利用します。`,
+    `そのため、Todoアイテムの状態を更新するには、HTML要素にTodoアイテムの情報（タイトルや識別子となるidなど）をすべて埋め込む必要があります。
+しかし、HTML要素に対して文字列しか埋め込めないため、Todoアイテムのデータを文字列にしないといけないという制限が発生します。
+
+また操作と表示が1対1で更新される場合、1つの操作に対して複数の箇所の表示が更新されることもあります。
+今回のTodoアプリでもTodoリスト（\`#js-todo-list\`）とTodoアイテム数（\`#js-todo-count\`）の2箇所を更新する必要があることからも分かります。
+`
+  ],
+  invalid: [
+    {
+      text: '【重要】これは（秘密）です。',
+      options: {
+        disallowBrackets: [FullWidthParenthesis, LenticularBrackets]
+      },
+      errors: [
+        {
+          index: 1,
+          message: `Disallow Lenticular Brackets '【' and '】'.`
+        },
+        {
+          index: 8,
+          message: `Disallow Full-Width Parenthesis '（' and '）'.`
+        }
+      ]
+    },
+    {
+      text:
+        '`src/App.js`にファイルを作成し、次のような内容のJavaScriptモジュールとします。\n' +
+        'モジュールは、基本的には何かしらを外部に公開(`export`)します。',
+      options: {
+        disallowBrackets: [Parenthesis]
+      },
+      errors: [
+        {
+          index: 74
+        }
+      ]
+    },
+    {
+      text: `このように\`count\`変数が自動解放されずに保持できているのは「（\`increment\`）関数が外側のスコープにある（\`count\`）変数への参照を保持できる」ためです。このような性質のことをクロージャー(関数閉包)と呼びます。クロージャーは静的スコープと変数は参照され続けていればデータは保持されるという2つの性質によって成り立っています。`,
+      options: {
+        disallowBrackets: [FullWidthParenthesis, CornerBrackets]
+      },
+      errors: [
+        {
+          line: 1,
+          column: 34,
+          index: 33,
+          message: `Disallow Corner Brackets '「' and '」'.`
+        },
+        {
+          line: 1,
+          column: 35,
+          index: 34,
+          message: `Disallow Full-Width Parenthesis '（' and '）'.`
+        },
+        {
+          line: 1,
+          column: 61,
+          index: 60,
+          message: `Disallow Full-Width Parenthesis '（' and '）'.`
+        }
+      ]
+    },
+    {
+      text: `DUMMY DUUMY.
+
+
+このように\`count\`変数が自動解放されずに保持できているのは「（\`increment\`）関数が外側のスコープにある（\`count\`）変数への参照を保持できる」ためです。このような性質のことをクロージャー(関数閉包)と呼びます。クロージャーは静的スコープと変数は参照され続けていればデータは保持されるという2つの性質によって成り立っています。`,
+      options: {
+        disallowBrackets: [FullWidthParenthesis, CornerBrackets]
+      },
+      errors: [
+        {
+          line: 4,
+          column: 34,
+          index: 48
+        },
+        {
+          line: 4,
+          column: 35,
+          index: 49
+        },
+        {
+          line: 4,
+          column: 61,
+          index: 75
+        }
+      ]
+    }
+  ]
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/textlint-rule-no-bracket/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR provides the core feature of `textlint-rule-no-bracket`.

The following is an overview of the core features:

- This rule allows all brackets **by default**
- **Specify disallow brackets in blacklist** in `no-bracket`
- This rule exports built-in brackets, so you can use it to set the `no-bracket` option.
- The target brackets must be a pair of brackets.

### Additional context

This rule will work well in combination with [`textlint-rule-no-unmatched-pair`](https://github.com/textlint-rule/textlint-rule-no-unmatched-pair)